### PR TITLE
add multi-display support

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -47,6 +47,12 @@ contextBridge.exposeInMainWorld('electron', {
   appendToLog: (data) => ipcRenderer.invoke('append-to-log', data),
   onSerialData: (callback) => ipcRenderer.on('serial-data', (event, data) => callback(data)),
   deliverWater: () => ipcRenderer.invoke('deliver-water'),
+  getDisplays: () => ipcRenderer.invoke('get-displays'),
+  setPreferredDisplay: (displayId) => ipcRenderer.send('set-preferred-display', displayId),
+  getPreferredDisplay: () => ipcRenderer.invoke('get-preferred-display'),
+  onDisplayChanged: (callback) => {
+    ipcRenderer.on('display-changed', (_, displayId) => callback(displayId))
+  }
 })
 
 console.log('Preload: Script initialized')

--- a/src/components/NavigationBar.vue
+++ b/src/components/NavigationBar.vue
@@ -1,9 +1,62 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+
+const displays = ref([])
+const selectedDisplay = ref(null)
+
+onMounted(async () => {
+  if (window.electron) {
+    const availableDisplays = await window.electron.getDisplays()
+    displays.value = availableDisplays
+    
+    const preferredDisplayId = await window.electron.getPreferredDisplay()
+    selectedDisplay.value = preferredDisplayId || availableDisplays.find(d => d.isPrimary)?.id
+    
+    handleDisplayChange(selectedDisplay.value)
+    
+    window.electron.onDisplayChanged((displayId) => {
+      selectedDisplay.value = Number(displayId)
+    })
+  }
+})
+
+const handleDisplayChange = (displayId) => {
+  if (!displayId) return
+  
+  selectedDisplay.value = Number(displayId)
+  if (window.electron) {
+    window.electron.setPreferredDisplay(selectedDisplay.value)
+  }
+}
+</script>
+
 <template>
   <nav class="navigation">
     <div class="nav-content">
-      <router-link to="/" class="nav-link">Observe Gallery</router-link>
-      <router-link to="/physics-mazes" class="nav-link">Interactive Mazes</router-link>
-      <router-link to="/serial-control" class="nav-link">Serial Control</router-link>
+      <div class="nav-links">
+        <router-link to="/" class="nav-link">Observe Gallery</router-link>
+        <router-link to="/physics-mazes" class="nav-link">Interactive Mazes</router-link>
+        <router-link to="/serial-control" class="nav-link">Serial Control</router-link>
+      </div>
+      
+      <!-- Display selector -->
+      <div class="display-selector">
+        <label for="display-select">Display:</label>
+        <select 
+          id="display-select" 
+          v-model="selectedDisplay"
+          @change="handleDisplayChange($event.target.value)"
+          class="display-select"
+        >
+          <option 
+            v-for="display in displays" 
+            :key="display.id" 
+            :value="display.id"
+          >
+            {{ display.isPrimary ? 'Primary Display' : `Display ${display.id}` }}
+          </option>
+        </select>
+      </div>
     </div>
   </nav>
 </template>
@@ -21,11 +74,16 @@
 
 .nav-content {
   max-width: 1200px;
-
   margin: 0 auto;
   display: flex;
-  gap: 2rem;
+  justify-content: space-between;
+  align-items: center;
   padding: 0 2rem;
+}
+
+.nav-links {
+  display: flex;
+  gap: 2rem;
 }
 
 .nav-link {
@@ -43,5 +101,35 @@
 
 .router-link-active {
   background-color: #333;
+}
+
+.display-selector {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.display-selector label {
+  color: white;
+  font-size: 1rem;
+}
+
+.display-select {
+  background-color: #333;
+  color: white;
+  border: none;
+  padding: 0.5rem;
+  border-radius: 4px;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.display-select:hover {
+  background-color: #444;
+}
+
+.display-select:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #666;
 }
 </style> 

--- a/src/scenes/serial/JsSerialHallwayScene.vue
+++ b/src/scenes/serial/JsSerialHallwayScene.vue
@@ -133,7 +133,7 @@ function animate() {
       })
 
       // Prepare and log data
-      const logData = `${position.value.x.toFixed(3)}\t${position.value.y.toFixed(3)}\t${position.value.theta.toFixed(3)}\t1\t${serialData.value.water ? 1 : 0}\t${serialData.value.timestamp}\n`
+      const logData = `${position.value.x.toFixed(3)}\t${position.value.y.toFixed(3)}\t${position.value.theta.toFixed(3)}\t${serialData.value.x || 0}\t${serialData.value.y || 0}\t${serialData.value.water ? 1 : 0}\t${serialData.value.timestamp}\n`
       window.electron.appendToLog(logData)
 
       // Clear the processed serial data


### PR DESCRIPTION
- Add display selector in navigation bar for multi-screen setups
- Store and restore preferred display settings
- Automatically position scene windows on selected display
- Update data logging format to include raw input values
- Persist display preferences between sessions

The display selector allows users to choose which screen should show
the maze scenes, improving the setup for multi-monitor configurations.